### PR TITLE
fix: update jupyterlab plotly widget installation method

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="lucas@loftorbital.com"
 USER root
 
 # Install extensions
-RUN pip install "jupyterlab>=3" "ipywidgets>=7.6"
+RUN pip install "ipywidgets>=7.6"
 
 COPY ./shortcuts-extension /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/shortcuts-extension
 

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -9,8 +9,7 @@ LABEL maintainer="lucas@loftorbital.com"
 USER root
 
 # Install extensions
-
-RUN jupyter labextension install jupyterlab-plotly
+RUN pip install "jupyterlab>=3" "ipywidgets>=7.6"
 
 COPY ./shortcuts-extension /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/shortcuts-extension
 

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -9,14 +9,13 @@ LABEL maintainer="lucas@loftorbital.com"
 USER root
 
 # Install extensions
-RUN pip install "ipywidgets>=7.6"
+
+RUN pip install "plotly" "numpy" "ipywidgets>=7.6"
+
+RUN jupyter labextension install --no-build \
+        @jupyterlab/shortcuts-extension
 
 COPY ./shortcuts-extension /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/shortcuts-extension
-
-# Install NumPy and Plotly
-
-RUN python -m pip install --quiet numpy --upgrade \
- && python -m pip install --quiet plotly
 
 RUN chown -R ${NB_UID}:${NB_UID} /home/jovyan/.jupyter
 


### PR DESCRIPTION
Looks like we were using a deprecated method of installing extension for Jupyterlab:
```
(Deprecated) Installing extensions with the jupyter labextension install command is now deprecated and will be removed in a future major version of JupyterLab.
#0 31.62 
#0 31.62 Users should manage prebuilt extensions with package managers like pip and conda, and extension authors are encouraged to distribute their extensions as prebuilt packages
```