### PR TITLE
revert: refactor: rename abbreviated namespaces to full pathing

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/Directory.cpp
+++ b/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/Directory.cpp
@@ -6,7 +6,7 @@ inline void OpenSpaceToolkitCorePy_FileSystem_Directory(pybind11::module& aModul
 {
     using namespace pybind11;
 
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Directory;
 
     class_<Directory>(aModule, "Directory")
 
@@ -17,8 +17,8 @@ inline void OpenSpaceToolkitCorePy_FileSystem_Directory(pybind11::module& aModul
         .def(self == self)
         .def(self != self)
 
-        // .def("__str__", +[] (const ostk::core::filesystem::Directory& aDirectory) -> str { return aDirectory.toString() ; })
-        // .def("__repr__", +[] (const ostk::core::filesystem::Directory& aDirectory) -> str { return aDirectory.toString() ; })
+        // .def("__str__", +[] (const ostk::core::fs::Directory& aDirectory) -> str { return aDirectory.toString() ; })
+        // .def("__repr__", +[] (const ostk::core::fs::Directory& aDirectory) -> str { return aDirectory.toString() ; })
         .def("__str__", &(shiftToString<Directory>))
         .def("__repr__", &(shiftToString<Directory>))
 

--- a/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/File.cpp
+++ b/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/File.cpp
@@ -6,7 +6,7 @@ inline void OpenSpaceToolkitCorePy_FileSystem_File(pybind11::module& aModule)
 {
     using namespace pybind11;
 
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::File;
 
     class_<File>(aModule, "File")
 
@@ -17,8 +17,8 @@ inline void OpenSpaceToolkitCorePy_FileSystem_File(pybind11::module& aModule)
         .def(self == self)
         .def(self != self)
 
-        // .def("__str__", +[] (const ostk::core::filesystem::File& aFile) -> str { return aFile.toString() ; })
-        // .def("__repr__", +[] (const ostk::core::filesystem::File& aFile) -> str { return aFile.toString() ; })
+        // .def("__str__", +[] (const ostk::core::fs::File& aFile) -> str { return aFile.toString() ; })
+        // .def("__repr__", +[] (const ostk::core::fs::File& aFile) -> str { return aFile.toString() ; })
         .def("__str__", &(shiftToString<File>))
         .def("__repr__", &(shiftToString<File>))
 

--- a/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/Path.cpp
+++ b/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/Path.cpp
@@ -6,7 +6,7 @@ inline void OpenSpaceToolkitCorePy_FileSystem_Path(pybind11::module& aModule)
 {
     using namespace pybind11;
 
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     class_<Path>(aModule, "Path")
 
@@ -20,8 +20,8 @@ inline void OpenSpaceToolkitCorePy_FileSystem_Path(pybind11::module& aModule)
         .def(self + self)
         .def(self += self)
 
-        // .def("__str__", +[] (const ostk::core::filesystem::Path& aPath) -> str { return aPath.toString() ; })
-        // .def("__repr__", +[] (const ostk::core::filesystem::Path& aPath) -> str { return aPath.toString() ; })
+        // .def("__str__", +[] (const ostk::core::fs::Path& aPath) -> str { return aPath.toString() ; })
+        // .def("__repr__", +[] (const ostk::core::fs::Path& aPath) -> str { return aPath.toString() ; })
         .def("__str__", &(shiftToString<Path>))
         .def("__repr__", &(shiftToString<Path>))
 

--- a/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/PermissionSet.cpp
+++ b/bindings/python/src/OpenSpaceToolkitCorePy/FileSystem/PermissionSet.cpp
@@ -6,7 +6,7 @@ inline void OpenSpaceToolkitCorePy_FileSystem_PermissionSet(pybind11::module& aM
 {
     using namespace pybind11;
 
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     class_<PermissionSet>(aModule, "PermissionSet")
 
@@ -20,8 +20,8 @@ inline void OpenSpaceToolkitCorePy_FileSystem_PermissionSet(pybind11::module& aM
         .def(self + self)
         .def(self - self)
 
-        // .def("__str__", +[] (const ostk::core::filesystem::PermissionSet& aPermissionSet) -> str { return
-        // aPermissionSet.toString() ; }) .def("__repr__", +[] (const ostk::core::filesystem::PermissionSet& aPermissionSet) ->
+        // .def("__str__", +[] (const ostk::core::fs::PermissionSet& aPermissionSet) -> str { return
+        // aPermissionSet.toString() ; }) .def("__repr__", +[] (const ostk::core::fs::PermissionSet& aPermissionSet) ->
         // str { return aPermissionSet.toString() ; })
         .def("__str__", &(shiftToString<PermissionSet>))
         .def("__repr__", &(shiftToString<PermissionSet>))

--- a/bindings/python/src/OpenSpaceToolkitCorePy/Types/Real.cpp
+++ b/bindings/python/src/OpenSpaceToolkitCorePy/Types/Real.cpp
@@ -2,39 +2,14 @@
 
 #include <OpenSpaceToolkit/Core/Types/Real.hpp>
 
-using namespace pybind11;
-
-using ostk::core::types::Integer;
-using ostk::core::types::Real;
-using ostk::core::types::String;
-
-// Custom type caster for Real
-namespace pybind11
-{
-namespace detail
-{
-template <>
-struct type_caster<Real>
-{
-   public:
-    PYBIND11_TYPE_CASTER(Real, _("Real"));
-
-    bool load(handle src, bool convert)
-    {
-        value = Real(pybind11::cast<double>(src));
-        return true;
-    }
-
-    static handle cast(const Real& src, return_value_policy /* policy */, handle /* parent */)
-    {
-        return pybind11::cast((double)src).release();
-    }
-};
-}  // namespace detail
-}  // namespace pybind11
-
 inline void OpenSpaceToolkitCorePy_Types_Real(pybind11::module& aModule)
 {
+    using namespace pybind11;
+
+    using ostk::core::types::Integer;
+    using ostk::core::types::Real;
+    using ostk::core::types::String;
+
     class_<Real>(aModule, "Real")
 
         // Define init method using pybind11 "init" convenience method
@@ -126,27 +101,6 @@ inline void OpenSpaceToolkitCorePy_Types_Real(pybind11::module& aModule)
         .def_static("integer", &Real::Integer)
         .def_static("can_parse", &Real::CanParse)
         .def_static("parse", &Real::Parse)
-
-        .def(pickle(
-            [](const Real& aReal) -> double
-            {  // dump
-                return aReal;
-            },
-            [](double t)
-            {  // load
-                return Real(t);
-            }
-        ))
-
-        .def(
-            "__reduce__",
-            [](const Real& aReal)
-            {
-                auto py_json_module = module_::import("json");
-                auto py_json_dumps = py_json_module.attr("dumps");
-                return make_tuple(py_json_dumps, make_tuple(double(aReal)));
-            }
-        )
 
         ;
 

--- a/include/OpenSpaceToolkit/Core/Containers/Dictionary.hpp
+++ b/include/OpenSpaceToolkit/Core/Containers/Dictionary.hpp
@@ -17,7 +17,7 @@ namespace core
 namespace ctnr
 {
 
-namespace filesystem = ostk::core::filesystem;
+namespace fs = ostk::core::fs;
 
 using ostk::core::types::Size;
 using ostk::core::types::String;

--- a/include/OpenSpaceToolkit/Core/Containers/Object.hpp
+++ b/include/OpenSpaceToolkit/Core/Containers/Object.hpp
@@ -22,7 +22,7 @@ namespace core
 namespace ctnr
 {
 
-namespace filesystem = ostk::core::filesystem;
+namespace fs = ostk::core::fs;
 
 using ostk::core::types::Unique;
 
@@ -126,9 +126,9 @@ class Object
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const Object& anObject);
 
-    friend filesystem::File& operator<<(filesystem::File& aFile, const Object& anObject);
+    friend fs::File& operator<<(fs::File& aFile, const Object& anObject);
 
-    friend filesystem::File& operator>>(filesystem::File& aFile, Object& anObject);
+    friend fs::File& operator>>(fs::File& aFile, Object& anObject);
 
     bool isDefined() const;
     bool isBoolean() const;
@@ -180,7 +180,7 @@ class Object
 
     static Object Parse(const types::String& aString, const Object::Format& aFormat = Object::Format::Undefined);
 
-    static Object Load(const filesystem::File& aFile, const Object::Format& aFormat = Object::Format::Undefined);
+    static Object Load(const fs::File& aFile, const Object::Format& aFormat = Object::Format::Undefined);
 
     static types::String StringFromType(const Object::Type& aType);
 

--- a/include/OpenSpaceToolkit/Core/Containers/Table.hpp
+++ b/include/OpenSpaceToolkit/Core/Containers/Table.hpp
@@ -24,7 +24,7 @@ using ostk::core::types::String;
 using ostk::core::ctnr::Array;
 using ostk::core::ctnr::table::Row;
 using ostk::core::ctnr::table::Cell;
-using ostk::core::filesystem::File;
+using ostk::core::fs::File;
 
 /// @brief                      Table container
 

--- a/include/OpenSpaceToolkit/Core/FileSystem/Directory.hpp
+++ b/include/OpenSpaceToolkit/Core/FileSystem/Directory.hpp
@@ -13,7 +13,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 namespace ctnr = ostk::core::ctnr;
@@ -159,7 +159,7 @@ class Directory
     ///
     /// @return             Directory path
 
-    filesystem::Path getPath() const;
+    fs::Path getPath() const;
 
     /// @brief              Get directory permissions
     ///
@@ -170,7 +170,7 @@ class Directory
     ///
     /// @return             Directory permissions
 
-    filesystem::PermissionSet getPermissions() const;
+    fs::PermissionSet getPermissions() const;
 
     /// @brief              Get directory's parent directory
     ///
@@ -194,7 +194,7 @@ class Directory
     ///
     /// @return             Array of files in directory
 
-    ctnr::Array<filesystem::File> getFiles() const;
+    ctnr::Array<fs::File> getFiles() const;
 
     /// @brief              Get directories in directory
     ///
@@ -270,9 +270,9 @@ class Directory
     /// @param              [in] (optional) anOtherPermissionSet An other permission set
 
     void create(
-        const filesystem::PermissionSet& anOwnerPermissionSet = filesystem::PermissionSet::RWX(),
-        const filesystem::PermissionSet& aGroupPermissionSet = filesystem::PermissionSet::RX(),
-        const filesystem::PermissionSet& anOtherPermissionSet = filesystem::PermissionSet::RX()
+        const fs::PermissionSet& anOwnerPermissionSet = fs::PermissionSet::RWX(),
+        const fs::PermissionSet& aGroupPermissionSet = fs::PermissionSet::RX(),
+        const fs::PermissionSet& anOtherPermissionSet = fs::PermissionSet::RX()
     );
 
     /// @brief              Delete directory
@@ -317,15 +317,15 @@ class Directory
     /// @param              [in] aPath Path to directory
     /// @return             Directory
 
-    static Directory Path(const filesystem::Path& aPath);
+    static Directory Path(const fs::Path& aPath);
 
    private:
-    filesystem::Path path_;
+    fs::Path path_;
 
-    Directory(const filesystem::Path& aPath);
+    Directory(const fs::Path& aPath);
 };
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk
 

--- a/include/OpenSpaceToolkit/Core/FileSystem/File.hpp
+++ b/include/OpenSpaceToolkit/Core/FileSystem/File.hpp
@@ -15,7 +15,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 class Directory;
@@ -189,7 +189,7 @@ class File
     ///
     /// @return             File path
 
-    filesystem::Path getPath() const;
+    fs::Path getPath() const;
 
     /// @brief              Get file permissions
     ///
@@ -200,7 +200,7 @@ class File
     ///
     /// @return             File permissions
 
-    filesystem::PermissionSet getPermissions() const;
+    fs::PermissionSet getPermissions() const;
 
     /// @brief              Get file's parent directory
     ///
@@ -211,7 +211,7 @@ class File
     ///
     /// @return             File's parent directory
 
-    filesystem::Directory getParentDirectory() const;
+    fs::Directory getParentDirectory() const;
 
     /// @brief              Get file contents
     ///
@@ -268,7 +268,7 @@ class File
     /// @param              [in] (optional) aNewFileName A copied file name
     /// @return             Copied file
 
-    File copyToDirectory(const filesystem::Directory& aDestination, const String& aNewFileName = "") const;
+    File copyToDirectory(const fs::Directory& aDestination, const String& aNewFileName = "") const;
 
     /// @brief              Move file to directory
     ///
@@ -280,7 +280,7 @@ class File
     ///
     /// @param              [in] aDestination A destination directory
 
-    void moveToDirectory(const filesystem::Directory& aDestination);
+    void moveToDirectory(const fs::Directory& aDestination);
 
     /// @brief              Create empty file
     ///
@@ -296,9 +296,9 @@ class File
     /// @param              [in] (optional) anOtherPermissionSet An other permission set
 
     void create(
-        const filesystem::PermissionSet& anOwnerPermissionSet = filesystem::PermissionSet::RW(),
-        const filesystem::PermissionSet& aGroupPermissionSet = filesystem::PermissionSet::R(),
-        const filesystem::PermissionSet& anOtherPermissionSet = filesystem::PermissionSet::R()
+        const fs::PermissionSet& anOwnerPermissionSet = fs::PermissionSet::RW(),
+        const fs::PermissionSet& aGroupPermissionSet = fs::PermissionSet::R(),
+        const fs::PermissionSet& anOtherPermissionSet = fs::PermissionSet::R()
     );
 
     /// @brief              Clear file contents
@@ -344,17 +344,17 @@ class File
     /// @param              [in] aPath Path to file
     /// @return             File
 
-    static File Path(const filesystem::Path& aPath);
+    static File Path(const fs::Path& aPath);
 
    private:
-    filesystem::Path path_;
+    fs::Path path_;
 
     Unique<std::fstream> fileStreamUPtr_;
 
-    File(const filesystem::Path& aPath);
+    File(const fs::Path& aPath);
 };
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk
 

--- a/include/OpenSpaceToolkit/Core/FileSystem/Path.hpp
+++ b/include/OpenSpaceToolkit/Core/FileSystem/Path.hpp
@@ -12,7 +12,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 using ostk::core::types::Unique;
@@ -268,7 +268,7 @@ class Path
     Path();
 };
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk
 

--- a/include/OpenSpaceToolkit/Core/FileSystem/PermissionSet.hpp
+++ b/include/OpenSpaceToolkit/Core/FileSystem/PermissionSet.hpp
@@ -9,7 +9,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 /// @brief                      Permissions control the ability of the users to view, change, navigate, and execute the
@@ -261,7 +261,7 @@ class PermissionSet
     bool execute_;
 };
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk
 

--- a/include/OpenSpaceToolkit/Core/FileSystem/SymbolicLink.hpp
+++ b/include/OpenSpaceToolkit/Core/FileSystem/SymbolicLink.hpp
@@ -7,14 +7,14 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 /// @brief
 
 // [TBI]
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk
 

--- a/src/OpenSpaceToolkit/Core/Containers/Object.cpp
+++ b/src/OpenSpaceToolkit/Core/Containers/Object.cpp
@@ -456,7 +456,7 @@ std::ostream& operator<<(std::ostream& anOutputStream, const Object& anObject)
     return anOutputStream;
 }
 
-filesystem::File& operator<<(filesystem::File& aFile, const Object& anObject)
+fs::File& operator<<(fs::File& aFile, const Object& anObject)
 {
     // [TBM] This should be improved, supporting format manipulators and iterative string generation
 
@@ -465,7 +465,7 @@ filesystem::File& operator<<(filesystem::File& aFile, const Object& anObject)
     return aFile;
 }
 
-filesystem::File& operator>>(filesystem::File& aFile, Object& anObject)
+fs::File& operator>>(fs::File& aFile, Object& anObject)
 {
     // [TBM] This should be improved, supporting format manipulators
 
@@ -1048,7 +1048,7 @@ Object Object::ParseYaml(const types::String& aString)
     }
 }
 
-Object Object::Load(const filesystem::File& aFile, const Object::Format& aFormat)
+Object Object::Load(const fs::File& aFile, const Object::Format& aFormat)
 {
     LOG_SCOPE("Object", "Load");
 

--- a/src/OpenSpaceToolkit/Core/FileSystem/Directory.cpp
+++ b/src/OpenSpaceToolkit/Core/FileSystem/Directory.cpp
@@ -10,7 +10,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 bool Directory::operator==(const Directory& aDirectory) const
@@ -157,7 +157,7 @@ String Directory::getName() const
     return String::Empty();
 }
 
-filesystem::Path Directory::getPath() const
+fs::Path Directory::getPath() const
 {
     if (!this->isDefined())
     {
@@ -167,7 +167,7 @@ filesystem::Path Directory::getPath() const
     return path_;
 }
 
-// filesystem::PermissionSet               Directory::getPermissions                   ( ) const
+// fs::PermissionSet               Directory::getPermissions                   ( ) const
 // {
 //     return File::Path(path_).getPermissions() ;
 // }
@@ -177,7 +177,7 @@ Directory Directory::getParentDirectory() const
     return File::Path(path_).getParentDirectory();
 }
 
-// ctnr::Array<filesystem::File>           Directory::getFiles                         ( ) const
+// ctnr::Array<fs::File>           Directory::getFiles                         ( ) const
 // {
 
 // }
@@ -249,9 +249,9 @@ String Directory::toString() const
 // }
 
 void Directory::create(
-    const filesystem::PermissionSet& anOwnerPermissionSet,
-    const filesystem::PermissionSet& aGroupPermissionSet,
-    const filesystem::PermissionSet& anOtherPermissionSet
+    const fs::PermissionSet& anOwnerPermissionSet,
+    const fs::PermissionSet& aGroupPermissionSet,
+    const fs::PermissionSet& anOtherPermissionSet
 )
 {
     if (this->exists())
@@ -314,7 +314,7 @@ Directory Directory::Root()
     return {Path::Parse("/")};
 }
 
-Directory Directory::Path(const filesystem::Path& aPath)
+Directory Directory::Path(const fs::Path& aPath)
 {
     if (!aPath.isDefined())
     {
@@ -324,11 +324,11 @@ Directory Directory::Path(const filesystem::Path& aPath)
     return {aPath};
 }
 
-Directory::Directory(const filesystem::Path& aPath)
+Directory::Directory(const fs::Path& aPath)
     : path_(aPath)
 {
 }
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk

--- a/src/OpenSpaceToolkit/Core/FileSystem/File.cpp
+++ b/src/OpenSpaceToolkit/Core/FileSystem/File.cpp
@@ -15,7 +15,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 File::File(const File& aFile)
@@ -160,7 +160,7 @@ String File::getExtension() const
     return String::Empty();
 }
 
-filesystem::Path File::getPath() const
+fs::Path File::getPath() const
 {
     if (!this->isDefined())
     {
@@ -170,11 +170,11 @@ filesystem::Path File::getPath() const
     return path_;
 }
 
-filesystem::PermissionSet File::getPermissions() const
+fs::PermissionSet File::getPermissions() const
 {
     // https://linux.die.net/man/2/access
 
-    const auto handleErrorForPath = [](const filesystem::Path& aPath) -> void
+    const auto handleErrorForPath = [](const fs::Path& aPath) -> void
     {
         switch (errno)
         {
@@ -238,7 +238,7 @@ filesystem::PermissionSet File::getPermissions() const
         }
     };
 
-    const auto canRead = [&handleErrorForPath](const filesystem::Path& aPath) -> bool
+    const auto canRead = [&handleErrorForPath](const fs::Path& aPath) -> bool
     {
         const int result = access(aPath.toString().data(), R_OK);
 
@@ -250,7 +250,7 @@ filesystem::PermissionSet File::getPermissions() const
         return result == 0;
     };
 
-    const auto canWrite = [&handleErrorForPath](const filesystem::Path& aPath) -> bool
+    const auto canWrite = [&handleErrorForPath](const fs::Path& aPath) -> bool
     {
         const int result = access(aPath.toString().data(), W_OK);
 
@@ -262,7 +262,7 @@ filesystem::PermissionSet File::getPermissions() const
         return result == 0;
     };
 
-    const auto canExecute = [&handleErrorForPath](const filesystem::Path& aPath) -> bool
+    const auto canExecute = [&handleErrorForPath](const fs::Path& aPath) -> bool
     {
         const int result = access(aPath.toString().data(), X_OK);
 
@@ -282,7 +282,7 @@ filesystem::PermissionSet File::getPermissions() const
     return {canRead(path_), canWrite(path_), canExecute(path_)};
 }
 
-filesystem::Directory File::getParentDirectory() const
+fs::Directory File::getParentDirectory() const
 {
     if (!this->isDefined())
     {
@@ -305,10 +305,10 @@ filesystem::Directory File::getParentDirectory() const
 
     if (filePathString == "/")
     {
-        return filesystem::Directory::Root();
+        return fs::Directory::Root();
     }
 
-    return filesystem::Directory::Path(Path::Parse(filePathString).getParentPath());
+    return fs::Directory::Path(Path::Parse(filePathString).getParentPath());
 }
 
 String File::getContents() const
@@ -448,13 +448,13 @@ std::fstream& File::accessStream()
 
 // }
 
-// File                            File::copyToDirectory                       (   const   filesystem::Directory& aDestination,
+// File                            File::copyToDirectory                       (   const   fs::Directory& aDestination,
 //                                                                                 const   String& aNewFileName ) const
 // {
 
 // }
 
-void File::moveToDirectory(const filesystem::Directory& aDestination)
+void File::moveToDirectory(const fs::Directory& aDestination)
 {
     if (!this->exists())
     {
@@ -466,7 +466,7 @@ void File::moveToDirectory(const filesystem::Directory& aDestination)
         throw ostk::core::error::RuntimeError("Destination [{}] does not exist.", aDestination.toString());
     }
 
-    const filesystem::Path destinationPath = aDestination.getPath() + Path::Parse(this->getName());
+    const fs::Path destinationPath = aDestination.getPath() + Path::Parse(this->getName());
 
     try
     {
@@ -481,9 +481,9 @@ void File::moveToDirectory(const filesystem::Directory& aDestination)
 }
 
 void File::create(
-    const filesystem::PermissionSet& anOwnerPermissionSet,
-    const filesystem::PermissionSet& aGroupPermissionSet,
-    const filesystem::PermissionSet& anOtherPermissionSet
+    const fs::PermissionSet& anOwnerPermissionSet,
+    const fs::PermissionSet& aGroupPermissionSet,
+    const fs::PermissionSet& anOtherPermissionSet
 )
 {
     if (this->exists())
@@ -491,14 +491,14 @@ void File::create(
         throw ostk::core::error::RuntimeError("File [{}] already exists.", this->toString());
     }
 
-    filesystem::Directory parentDirectory = this->getParentDirectory();
+    fs::Directory parentDirectory = this->getParentDirectory();
 
     if (!parentDirectory.exists())
     {
         parentDirectory.create();
     }
 
-    const filesystem::Path filePath = path_;
+    const fs::Path filePath = path_;
 
     std::fstream fileStream;
 
@@ -552,7 +552,7 @@ File File::Undefined()
     return {Path::Undefined()};
 }
 
-File File::Path(const filesystem::Path& aPath)
+File File::Path(const fs::Path& aPath)
 {
     if (!aPath.isDefined())
     {
@@ -562,12 +562,12 @@ File File::Path(const filesystem::Path& aPath)
     return {aPath};
 }
 
-File::File(const filesystem::Path& aPath)
+File::File(const fs::Path& aPath)
     : path_(aPath),
       fileStreamUPtr_(nullptr)
 {
 }
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk

--- a/src/OpenSpaceToolkit/Core/FileSystem/Path.cpp
+++ b/src/OpenSpaceToolkit/Core/FileSystem/Path.cpp
@@ -11,7 +11,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 class Path::Impl
@@ -295,6 +295,6 @@ Path::Path()
 {
 }
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk

--- a/src/OpenSpaceToolkit/Core/FileSystem/PermissionSet.cpp
+++ b/src/OpenSpaceToolkit/Core/FileSystem/PermissionSet.cpp
@@ -8,7 +8,7 @@ namespace ostk
 {
 namespace core
 {
-namespace filesystem
+namespace fs
 {
 
 PermissionSet::PermissionSet(const bool canRead, const bool canWrite, const bool canExecute)
@@ -140,6 +140,6 @@ PermissionSet PermissionSet::RWX()
     return {true, true, true};
 }
 
-}  // namespace filesystem
+}  // namespace fs
 }  // namespace core
 }  // namespace ostk

--- a/test/OpenSpaceToolkit/Core/Containers/Object.test.cpp
+++ b/test/OpenSpaceToolkit/Core/Containers/Object.test.cpp
@@ -211,8 +211,8 @@ TEST(OpenSpaceToolkit_Core_Containers_Object, StreamOperator)
 TEST(OpenSpaceToolkit_Core_Containers_Object, OutputFileStreamOperator)
 {
     using ostk::core::ctnr::Object;
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         Object object = Object::Undefined();
@@ -253,8 +253,8 @@ TEST(OpenSpaceToolkit_Core_Containers_Object, OutputFileStreamOperator)
 TEST(OpenSpaceToolkit_Core_Containers_Object, InputFileStreamOperator)
 {
     using ostk::core::ctnr::Object;
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         Object object = Object::Undefined();

--- a/test/OpenSpaceToolkit/Core/Containers/Table.test.cpp
+++ b/test/OpenSpaceToolkit/Core/Containers/Table.test.cpp
@@ -674,8 +674,8 @@ TEST(OpenSpaceToolkit_Core_Containers_Table, Load)
     using ostk::core::ctnr::Object;
     using ostk::core::ctnr::Table;
     using ostk::core::ctnr::table::Row;
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         const Array<String> header = {"A", "B", "C", "D", "E", "F"};

--- a/test/OpenSpaceToolkit/Core/FileSystem/Directory.test.cpp
+++ b/test/OpenSpaceToolkit/Core/FileSystem/Directory.test.cpp
@@ -6,8 +6,8 @@
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, EqualToOperator)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_TRUE(Directory::Path(Path::Parse("/")) == Directory::Path(Path::Parse("/")));
@@ -37,8 +37,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, EqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, NotEqualToOperator)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_TRUE(
@@ -68,8 +68,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, NotEqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, StreamOperator)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         const Directory directory = Directory::Path(Path::Parse("/path/to/directory"));
@@ -84,8 +84,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, StreamOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, IsDefined)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_TRUE(Directory::Path(Path::Parse("/")).isDefined());
@@ -100,8 +100,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, IsDefined)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Exists)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_TRUE(Directory::Path(Path::Parse("/")).exists());
@@ -121,8 +121,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Exists)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, IsEmpty)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_TRUE(Directory::Path(Path::Parse("/usr/games")).isEmpty());
@@ -143,8 +143,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, IsEmpty)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ContainsFileWithName)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         const Directory directory = Directory::Path(Path::Parse("/app/include/OpenSpaceToolkit/Core"));
@@ -169,8 +169,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ContainsFileWithName)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Directory, ContainsDirectoryWithName)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::Directory ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::Directory ;
 
 //     {
 
@@ -182,8 +182,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ContainsFileWithName)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetName)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_EQ("/", Directory::Path(Path::Parse("/")).getName());
@@ -200,8 +200,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetName)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetPath)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_EQ(Path::Parse("/"), Directory::Path(Path::Parse("/")).getPath());
@@ -219,9 +219,9 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetPath)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Directory, GetPermissions)
 // {
 
-//     using ostk::core::filesystem::PermissionSet ;
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::Directory ;
+//     using ostk::core::fs::PermissionSet ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::Directory ;
 
 //     {
 
@@ -274,8 +274,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetPath)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetParentDirectory)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_EQ(
@@ -322,8 +322,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetParentDirectory)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Directory, GetFiles)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::Directory ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::Directory ;
 
 //     {
 
@@ -343,8 +343,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetDirectories)
 {
     using ostk::core::types::String;
     using ostk::core::ctnr::Array;
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         const Directory directory = Directory::Path(Path::Parse("/app/tools"));
@@ -372,8 +372,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, GetDirectories)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ToString)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_EQ("/app/build", Directory::Path(Path::Parse("/app/build")).toString());
@@ -391,8 +391,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ToString)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Directory, RenameTo)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::Directory ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::Directory ;
 
 //     {
 
@@ -411,8 +411,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ToString)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Directory, CopyToDirectory)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::Directory ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::Directory ;
 
 //     {
 
@@ -431,8 +431,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ToString)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Directory, MoveToDirectory)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::Directory ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::Directory ;
 
 //     {
 
@@ -450,8 +450,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, ToString)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Create)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         Directory directory = Directory::Path(Path::Parse("/tmp/open-space-toolkit-core-filesystem-directory-create"));
@@ -474,8 +474,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Create)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Remove)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         Directory directory = Directory::Path(Path::Parse("/tmp/open-space-toolkit-core-filesystem-directory-remove"));
@@ -498,8 +498,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Remove)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Undefined)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_NO_THROW(Directory::Undefined());
@@ -509,8 +509,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Undefined)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Root)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_NO_THROW(Directory::Root());
@@ -521,8 +521,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Root)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Directory, Path)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::Directory;
 
     {
         const Path path = Path::Parse("/path/to/directory");

--- a/test/OpenSpaceToolkit/Core/FileSystem/File.test.cpp
+++ b/test/OpenSpaceToolkit/Core/FileSystem/File.test.cpp
@@ -7,8 +7,8 @@
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, EqualToOperator)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         EXPECT_TRUE(File::Path(Path::Parse("/")) == File::Path(Path::Parse("/")));
@@ -30,8 +30,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, EqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, NotEqualToOperator)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         EXPECT_TRUE(File::Path(Path::Parse("/path/to/file")) != File::Path(Path::Parse("/path/to/file/")));
@@ -53,8 +53,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, NotEqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, StreamOperator)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         const File file = File::Path(Path::Parse("/path/to/file"));
@@ -69,8 +69,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, StreamOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, FileStreamOperator)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         File file = File::Path(Path::Parse("/tmp/file.txt"));
@@ -96,8 +96,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, FileStreamOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, IsDefined)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         EXPECT_TRUE(File::Path(Path::Parse("/")).isDefined());
@@ -112,8 +112,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, IsDefined)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, Exists)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         EXPECT_TRUE(File::Path(Path::Parse("/")).exists());
@@ -133,8 +133,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, Exists)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, IsOpen)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         File file = File::Path(Path::Parse("/app/CMakeLists.txt"));
@@ -158,8 +158,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, IsOpen)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, GetName)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     // With extension
 
@@ -188,8 +188,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, GetName)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, GetExtension)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         EXPECT_TRUE(File::Path(Path::Parse("/")).exists());
@@ -209,8 +209,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, GetExtension)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, GetPath)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         const Path path = Path::Parse("/path/to/file");
@@ -225,9 +225,9 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, GetPath)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, GetPermissions)
 {
-    using ostk::core::filesystem::PermissionSet;
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::PermissionSet;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         const Path path = Path::Parse("/app/build");
@@ -260,9 +260,9 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, GetPermissions)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, GetParentDirectory)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
+    using ostk::core::fs::Directory;
 
     {
         EXPECT_EQ(
@@ -280,8 +280,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, GetParentDirectory)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, ToString)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         EXPECT_EQ("CMakeLists.txt", File::Path(Path::Parse("CMakeLists.txt")).toString());
@@ -296,8 +296,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, ToString)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, Open)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         File file = File::Path(Path::Parse("/app/CMakeLists.txt"));
@@ -319,8 +319,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, Open)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, Close)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         File file = File::Path(Path::Parse("/app/CMakeLists.txt"));
@@ -346,8 +346,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, Close)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, AccessStream)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         File file = File::Path(Path::Parse("/tmp/file.txt"));
@@ -374,8 +374,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, AccessStream)
 // TEST (OpenSpaceToolkit_Core_FileSystem_File, RenameTo)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::File ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::File ;
 
 //     {
 
@@ -388,8 +388,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, AccessStream)
 // TEST (OpenSpaceToolkit_Core_FileSystem_File, CopyToDirectory)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::File ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::File ;
 
 //     {
 
@@ -401,9 +401,9 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, AccessStream)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, MoveToDirectory)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
-    using ostk::core::filesystem::Directory;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
+    using ostk::core::fs::Directory;
 
     {
         File file = File::Path(Path::Parse("/tmp/file"));
@@ -438,8 +438,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, MoveToDirectory)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, Create)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         File file = File::Path(Path::Parse("/tmp/file"));
@@ -463,8 +463,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, Create)
 // TEST (OpenSpaceToolkit_Core_FileSystem_File, Clear)
 // {
 
-//     using ostk::core::filesystem::Path ;
-//     using ostk::core::filesystem::File ;
+//     using ostk::core::fs::Path ;
+//     using ostk::core::fs::File ;
 
 //     {
 
@@ -476,8 +476,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, Create)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, Remove)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         File file = File::Path(Path::Parse("/tmp/open-space-toolkit-core-filesystem-file-remove"));
@@ -500,8 +500,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, Remove)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, Undefined)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         EXPECT_NO_THROW(File::Undefined());
@@ -511,8 +511,8 @@ TEST(OpenSpaceToolkit_Core_FileSystem_File, Undefined)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_File, Path)
 {
-    using ostk::core::filesystem::Path;
-    using ostk::core::filesystem::File;
+    using ostk::core::fs::Path;
+    using ostk::core::fs::File;
 
     {
         const Path path = Path::Parse("/path/to/file");

--- a/test/OpenSpaceToolkit/Core/FileSystem/Path.test.cpp
+++ b/test/OpenSpaceToolkit/Core/FileSystem/Path.test.cpp
@@ -6,7 +6,7 @@
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, CopyConstructor)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         const Path path = Path::Parse("/abc/def.ghi");
@@ -19,7 +19,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, CopyConstructor)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, AssignmentOperator)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         const Path path = Path::Parse("/abc/def.ghi");
@@ -32,7 +32,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, AssignmentOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, EqualToOperator)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_TRUE(Path::Parse("/") == Path::Parse("/"));
@@ -54,7 +54,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, EqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, NotEqualToOperator)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_TRUE(Path::Parse("/path/to/file") != Path::Parse("/path/to/file/"));
@@ -76,7 +76,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, NotEqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, AdditionOperator)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         const Path firstPath = Path::Parse("/abc/def");
@@ -117,7 +117,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, AdditionOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, AdditionAssignmentOperator)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         Path firstPath = Path::Parse("/abc/def");
@@ -166,7 +166,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, AdditionAssignmentOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, StreamOperator)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         const Path path = Path::Parse("/abc/def.ghi");
@@ -181,7 +181,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, StreamOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, IsDefined)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_TRUE(Path::Parse("/").isDefined());
@@ -198,7 +198,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, IsDefined)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, IsAbsolute)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_TRUE(Path::Parse("/").isAbsolute());
@@ -232,7 +232,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, IsAbsolute)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, IsRelative)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_TRUE(Path::Parse("./").isRelative());
@@ -266,7 +266,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, IsRelative)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetParentPath)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_EQ(Path::Parse("/"), Path::Parse("/abc").getParentPath());
@@ -285,7 +285,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetParentPath)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetLastElement)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_EQ("/", Path::Parse("/").getLastElement());
@@ -317,7 +317,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetLastElement)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetNormalizedPath)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_EQ(Path::Parse("/"), Path::Parse("/").getNormalizedPath());
@@ -339,7 +339,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetNormalizedPath)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetAbsolutePath)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_EQ(Path::Parse("/"), Path::Parse("/").getAbsolutePath());
@@ -393,7 +393,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetAbsolutePath)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Path, GetRelativePathTo)
 // {
 
-//     using ostk::core::filesystem::Path ;
+//     using ostk::core::fs::Path ;
 
 //     {
 
@@ -405,7 +405,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetAbsolutePath)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, ToString)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_EQ("/", Path::Parse("/").toString());
@@ -422,7 +422,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, ToString)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, Undefined)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_NO_THROW(Path::Undefined());
@@ -432,7 +432,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, Undefined)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, Root)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_NO_THROW(Path::Root());
@@ -443,7 +443,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, Root)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, Current)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_NO_THROW(Path::Current());
@@ -453,7 +453,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, Current)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_Path, Parse)
 {
-    using ostk::core::filesystem::Path;
+    using ostk::core::fs::Path;
 
     {
         EXPECT_NO_THROW(Path::Parse("/"));
@@ -469,7 +469,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, Parse)
 // TEST (OpenSpaceToolkit_Core_FileSystem_Path, Strings)
 // {
 
-//     using ostk::core::filesystem::Path ;
+//     using ostk::core::fs::Path ;
 
 //     {
 

--- a/test/OpenSpaceToolkit/Core/FileSystem/PermissionSet.test.cpp
+++ b/test/OpenSpaceToolkit/Core/FileSystem/PermissionSet.test.cpp
@@ -6,7 +6,7 @@
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, Constructor)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         const bool canRead = false;
@@ -19,7 +19,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, Constructor)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, EqualToOperator)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_TRUE(PermissionSet(false, false, false) == PermissionSet(false, false, false));
@@ -36,7 +36,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, EqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, NotEqualToOperator)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_FALSE(PermissionSet(false, false, false) != PermissionSet(false, false, false));
@@ -53,7 +53,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, NotEqualToOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, AdditionOperator)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_EQ(PermissionSet::RWX(), PermissionSet::RW() + PermissionSet::X());
@@ -63,7 +63,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, AdditionOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, SubtractionOperator)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_EQ(PermissionSet::RW(), PermissionSet::RWX() - PermissionSet::X());
@@ -73,7 +73,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, SubtractionOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, LogicalAndOperator)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_EQ(PermissionSet::R(), PermissionSet::RW() && PermissionSet::RX());
@@ -85,7 +85,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, LogicalAndOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, LogicalOOperator)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_EQ(PermissionSet::RWX(), PermissionSet::RW() || PermissionSet::RX());
@@ -96,7 +96,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, LogicalOOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, StreamOperator)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         const PermissionSet permissionSet = {true, true, true};
@@ -111,7 +111,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, StreamOperator)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, IsNone)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_TRUE(PermissionSet(false, false, false).isNone());
@@ -128,7 +128,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, IsNone)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, IsAll)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_FALSE(PermissionSet(false, false, false).isAll());
@@ -145,7 +145,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, IsAll)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, CanRead)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_FALSE(PermissionSet(false, false, false).canRead());
@@ -162,7 +162,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, CanRead)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, CanWrite)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_FALSE(PermissionSet(false, false, false).canWrite());
@@ -179,7 +179,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, CanWrite)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, CanExecute)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_FALSE(PermissionSet(false, false, false).canExecute());
@@ -196,7 +196,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, CanExecute)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, None)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_NO_THROW(PermissionSet::None());
@@ -211,7 +211,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, None)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, R)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_NO_THROW(PermissionSet::R());
@@ -226,7 +226,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, R)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, W)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_NO_THROW(PermissionSet::W());
@@ -241,7 +241,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, W)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, X)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_NO_THROW(PermissionSet::X());
@@ -256,7 +256,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, X)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, RW)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_NO_THROW(PermissionSet::RW());
@@ -271,7 +271,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, RW)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, RX)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_NO_THROW(PermissionSet::RX());
@@ -286,7 +286,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, RX)
 
 TEST(OpenSpaceToolkit_Core_FileSystem_PermissionSet, RWX)
 {
-    using ostk::core::filesystem::PermissionSet;
+    using ostk::core::fs::PermissionSet;
 
     {
         EXPECT_NO_THROW(PermissionSet::RWX());


### PR DESCRIPTION
Reverts open-space-collective/open-space-toolkit-core#132