### PR TITLE
Draft: fix: add implicit conversion Real float

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitCorePy.cxx
+++ b/bindings/python/src/OpenSpaceToolkitCorePy.cxx
@@ -4,8 +4,8 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 
-#include <OpenSpaceToolkitCorePy/Containers.cpp>
-#include <OpenSpaceToolkitCorePy/FileSystem.cpp>
+// #include <OpenSpaceToolkitCorePy/Containers.cpp>
+// #include <OpenSpaceToolkitCorePy/FileSystem.cpp>
 #include <OpenSpaceToolkitCorePy/Types.cpp>
 
 PYBIND11_MODULE(OpenSpaceToolkitCorePy, m)
@@ -28,6 +28,6 @@ PYBIND11_MODULE(OpenSpaceToolkitCorePy, m)
 
     // Add python submodules to OpenSpaceToolkitCorePy
     OpenSpaceToolkitCorePy_Types(m);
-    OpenSpaceToolkitCorePy_Containers(m);
-    OpenSpaceToolkitCorePy_FileSystem(m);
+    // OpenSpaceToolkitCorePy_Containers(m);
+    // OpenSpaceToolkitCorePy_FileSystem(m);
 }

--- a/bindings/python/src/OpenSpaceToolkitCorePy/Containers/ArrayCasting.hpp
+++ b/bindings/python/src/OpenSpaceToolkitCorePy/Containers/ArrayCasting.hpp
@@ -1,8 +1,10 @@
 /// Apache License 2.0
 
 #include <pybind11/pybind11.h>
+// #include <pybind11/cast.h>
 #include <pybind11/stl.h>
 
+// #include <OpenSpaceToolkit/Core/Types/Real.hpp>
 #include <OpenSpaceToolkit/Core/Containers/Array.hpp>
 
 namespace pybind11
@@ -10,12 +12,32 @@ namespace pybind11
 namespace detail
 {
 
+// using ostk::core::types::Real;
 using ostk::core::ctnr::Array;
 
 template <typename T>
 struct type_caster<Array<T>> : list_caster<Array<T>, T>
 {
 };
+
+// template <>
+// struct type_caster<Real> {
+// public:
+//     PYBIND11_TYPE_CASTER(Real, _("Real"));
+
+//     // Convert Python object back to C++ Real
+//     bool load(handle src, bool convert) {
+//         if (!convert) return false;
+//         if (!pybind11::isinstance<pybind11::float_>(src)) return false;
+//         value = Real::ValueType(pybind11::cast<double>(src));
+//         return true;
+//     }
+
+//     // Convert Real to Python float
+//     static handle cast(const Real &src, return_value_policy /* policy */, handle /* parent */) {
+//         return pybind11::float_(Real::ValueType(src));
+//     }
+// };
 
 // using list_caster::load ;
 // using list_caster::cast ;

--- a/bindings/python/src/OpenSpaceToolkitCorePy/Types/Real.cpp
+++ b/bindings/python/src/OpenSpaceToolkitCorePy/Types/Real.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <pybind11/operators.h>
+
 #include <OpenSpaceToolkit/Core/Types/Real.hpp>
 
 inline void OpenSpaceToolkitCorePy_Types_Real(pybind11::module& aModule)
@@ -104,5 +106,6 @@ inline void OpenSpaceToolkitCorePy_Types_Real(pybind11::module& aModule)
 
         ;
 
-    implicitly_convertible<Real::ValueType, Real>();
+    implicitly_convertible<object, Real>();
+    implicitly_convertible<Real, Real::ValueType>();
 }

--- a/include/OpenSpaceToolkit/Core/Types/Real.hpp
+++ b/include/OpenSpaceToolkit/Core/Types/Real.hpp
@@ -75,6 +75,7 @@ class Real
     Real operator-() const;
 
     operator Real::ValueType() const;
+    // operator double() const;
 
     friend std::ostream& operator<<(std::ostream& anOutputStream, const Real& aReal);
 

--- a/src/OpenSpaceToolkit/Core/Types/Real.cpp
+++ b/src/OpenSpaceToolkit/Core/Types/Real.cpp
@@ -494,6 +494,16 @@ Real::operator Real::ValueType() const
     return value_;
 }
 
+// Real::operator Real::double() const
+// {
+//     if (type_ != Real::Type::Defined)
+//     {
+//         throw ostk::core::error::runtime::Undefined("Real");
+//     }
+
+//     return static_case<double>(value_);
+// }
+
 std::ostream& operator<<(std::ostream& anOutputStream, const Real& aReal)
 {
     (void)aReal;


### PR DESCRIPTION
- Context: Usually in python we have to use `float(a)` where `type(a)` is a `Real` from OSTk. This type is not directly serializable. What would be nice is having `Real` implicitly be converted to `float` when desired. 
- Draft 