### PR TITLE
build: rename wheel packaging for x86 to any

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -114,7 +114,7 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
 
     # Set platform name for wheel
     IF (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-        SET (PLATFORM "x86_64")
+        SET (PLATFORM "any")
     ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
         SET (PLATFORM "aarch64")
     ELSE ()


### PR DESCRIPTION
This is to ensure that our python package names for the x86 architecture remain consistent and don't cause any breaking changes down the line for other libraries that rely on the specific `-none-any` naming