### PR TITLE
build: rename wheel packaging for any to manylinux2014_x86_64

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -114,7 +114,7 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
 
     # Set platform name for wheel
     IF (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-        SET (PLATFORM "any")
+        SET (PLATFORM "manylinux2014_x86_64")
     ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
         SET (PLATFORM "manylinux2014_aarch64")
     ELSE ()


### PR DESCRIPTION
Having the current package platform description as `any` is technically not correct, so this should properly specify that it is for x86 architectures only

This is the packaging documentation
[packaging.python.org/en/latest/specifications/platform-compatibility-tags](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/)