### PR TITLE
chore: allow build without Boost Stacktrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Apache License 2.0
 
-## Project Properties
+# # Project Properties
 
 SET (PROJECT_NAME "OpenSpaceToolkitCore")
 SET (PROJECT_DESCRIPTION "Core library.")
@@ -12,7 +12,7 @@ SET (PROJECT_VENDOR_NAME "Open Space Collective")
 SET (PROJECT_VENDOR_CONTACT "contact@open-space-collective.org")
 SET (PROJECT_VENDOR_URL "open-space-collective.org")
 
-## Project Options
+# # Project Options
 
 OPTION (BUILD_SHARED_LIBRARY "Build shared library." ON)
 OPTION (BUILD_STATIC_LIBRARY "Build static library." OFF)
@@ -22,22 +22,24 @@ OPTION (BUILD_PYTHON_BINDINGS "Build Python bindings." ON)
 OPTION (BUILD_CODE_COVERAGE "Build code coverage" OFF)
 OPTION (BUILD_DOCUMENTATION "Build documentation" OFF)
 OPTION (BUILD_WITH_DEBUG_SYMBOLS "Build with debug symbols." ON)
+OPTION (BUILD_WITH_BOOST_STACKTRACE "Build with Boost Stacktrace instead of stacktrace basic" ON)
+OPTION (BUILD_WITH_BOOST_STATIC "Build with Boost Static lib" OFF)
 
-## Setup
+# # Setup
 
-### Compatibility Check
+# # # Compatibility Check
 
 CMAKE_MINIMUM_REQUIRED (VERSION "2.8.12" FATAL_ERROR)
 
-### Paths
+# # # Paths
 
-SET (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
+LIST (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
-### Policies
+# # # Policies
 
 CMAKE_POLICY (SET "CMP0048" NEW)
 
-## Version
+# # Version
 
 INCLUDE ("GetGitRevisionDescription" OPTIONAL)
 
@@ -99,7 +101,7 @@ ENDIF ()
 
 MESSAGE (STATUS "Version: ${PROJECT_VERSION_STRING}")
 
-## Project Configuration
+# # Project Configuration
 
 PROJECT (${PROJECT_NAME} VERSION ${PROJECT_VERSION_STRING} LANGUAGES "C" "CXX")
 
@@ -111,9 +113,9 @@ ELSEIF (NOT CMAKE_BUILD_TYPE)
     SET (CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type [None|Debug|Release|RelWithDebInfo|MinSizeRel]." FORCE)
 ENDIF ()
 
-## Flags
+# # Flags
 
-### Warnings
+# # # Warnings
 
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
@@ -131,13 +133,13 @@ ELSE ()
 
 ENDIF ()
 
-### C++ 17 support
+# # # C++ 17 support
 
 SET (CMAKE_CXX_STANDARD 20)
 SET (CMAKE_CXX_STANDARD_REQUIRED ON)
 SET (CMAKE_CXX_EXTENSIONS OFF)
 
-### Debug symbols
+# # # Debug symbols
 
 IF (BUILD_WITH_DEBUG_SYMBOLS)
 
@@ -145,19 +147,19 @@ IF (BUILD_WITH_DEBUG_SYMBOLS)
 
 ENDIF ()
 
-### Debugging Options
+# # # Debugging Options
 
 SET (CMAKE_VERBOSE_MAKEFILE 0) # Use 1 for debugging, 0 for release
 
-## Paths
+# # Paths
 
-### Search Paths
+# # # Search Paths
 
 LIST (APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}")
 LIST (APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/tools")
 LIST (APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/thirdparty")
 
-### Output Paths
+# # # Output Paths
 
 SET (EXECUTABLE_OUTPUT_PATH "${PROJECT_SOURCE_DIR}/bin")
 SET (LIBRARY_OUTPUT_PATH "${PROJECT_SOURCE_DIR}/lib")
@@ -189,7 +191,7 @@ ELSE ()
 
 ENDIF ()
 
-## Configure Files
+# # Configure Files
 
 FILE (GLOB_RECURSE CONFIGINPUTS1 "include/*.in.hpp.cmake")
 FILE (GLOB_RECURSE CONFIGINPUTS2 "include/*.hpp.in.cmake")
@@ -214,45 +216,53 @@ FOREACH (CONFIGINPUT ${CONFIGINPUTS})
 
 ENDFOREACH ()
 
-## Dependencies
+# Dependencies
 
-### Boost [1.82.0]
-
-SET (Boost_USE_STATIC_LIBS ON)
-SET (Boost_USE_MULTITHREADED ON)
-
-FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_backtrace")
-
-## Stacktrace definitions
-
-# Detect system architecture
-
-IF (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-
-    # Architecture-specific include for x86_64
-    SET (BACKTRACE_INCLUDE "/usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h")
-    
-ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-
-    # Example path adjustment for aarch64, adjust the path as needed
-    SET (BACKTRACE_INCLUDE "/usr/lib/gcc/aarch64-linux-gnu/9/include/backtrace.h")
-  
+# Boost [1.82.0
+IF (BUILD_WITH_BOOST_STATIC)
+    SET (Boost_USE_STATIC_LIBS ON)
 ELSE ()
-
-    MESSAGE (FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-    
+    SET (Boost_USE_STATIC_LIBS OFF)
 ENDIF ()
 
-# Add definitions with architecture-specific path
+SET (Boost_USE_MULTITHREADED ON)
 
-ADD_DEFINITIONS (-DBOOST_STACKTRACE_USE_BACKTRACE)
-ADD_DEFINITIONS (-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
+IF (BUILD_WITH_BOOST_STACKTRACE)
+
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_backtrace")
+
+    # Stacktrace definitions
+
+    # Detect system architecture
+
+    IF (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+
+        # Architecture-specific include for x86_64
+        SET (BACKTRACE_INCLUDE "/usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h")
+
+    ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+
+        # Example path adjustment for aarch64, adjust the path as needed
+        SET (BACKTRACE_INCLUDE "/usr/lib/gcc/aarch64-linux-gnu/9/include/backtrace.h")
+
+    ELSE ()
+        MESSAGE (FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+    ENDIF ()
+
+    # Add definitions with architecture-specific path
+    ADD_DEFINITIONS (-DBOOST_STACKTRACE_USE_BACKTRACE)
+    ADD_DEFINITIONS (-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
+
+ELSE ()
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_basic")
+ENDIF()
+
 
 IF (NOT Boost_FOUND)
     MESSAGE (SEND_ERROR "[Boost] not found.")
 ENDIF ()
 
-### RapidJSON [1.1.0]
+# # # RapidJSON [1.1.0]
 
 FIND_PACKAGE ("RapidJSON" REQUIRED)
 
@@ -262,11 +272,11 @@ ELSE ()
     MESSAGE (SEND_ERROR "[RapidJSON] not found.")
 ENDIF ()
 
-### yaml-cpp [0.7.0]
+# # # yaml-cpp [0.7.0]
 
 FIND_PACKAGE ("yaml-cpp" REQUIRED)
 
-## Versioning
+# # Versioning
 
 IF (DEFINED PROJECT_VERSION_STRING AND EXISTS "${PROJECT_SOURCE_DIR}/src/${PROJECT_PATH}/Utilities/Version.cpp.in")
 
@@ -274,9 +284,9 @@ IF (DEFINED PROJECT_VERSION_STRING AND EXISTS "${PROJECT_SOURCE_DIR}/src/${PROJE
 
 ENDIF ()
 
-## Targets
+# # Targets
 
-### Shared Library
+# # # Shared Library
 
 IF (BUILD_SHARED_LIBRARY)
 
@@ -312,7 +322,7 @@ IF (BUILD_SHARED_LIBRARY)
 
 ENDIF ()
 
-### Static Library
+# # # Static Library
 
 IF (BUILD_STATIC_LIBRARY)
 
@@ -338,7 +348,7 @@ IF (BUILD_STATIC_LIBRARY)
 
 ENDIF ()
 
-### Utility
+# # # Utility
 
 IF (BUILD_UTILITY)
 
@@ -366,7 +376,7 @@ IF (BUILD_UTILITY)
 
 ENDIF ()
 
-### Unit Tests
+# # # Unit Tests
 
 IF (BUILD_UNIT_TESTS)
 
@@ -412,7 +422,7 @@ IF (BUILD_UNIT_TESTS)
 
     INSTALL (TARGETS ${UNIT_TESTS_TARGET} DESTINATION ${INSTALL_TEST} COMPONENT "tests")
 
-    #### Code Coverage
+    # # # # Code Coverage
 
     IF (BUILD_CODE_COVERAGE)
 
@@ -434,7 +444,7 @@ IF (BUILD_UNIT_TESTS)
 
 ENDIF ()
 
-### Python Bindings
+# # # Python Bindings
 
 IF (BUILD_PYTHON_BINDINGS)
 
@@ -442,7 +452,7 @@ IF (BUILD_PYTHON_BINDINGS)
 
 ENDIF ()
 
-### Documentation
+# # # Documentation
 
 IF (BUILD_DOCUMENTATION)
 
@@ -450,31 +460,31 @@ IF (BUILD_DOCUMENTATION)
 
 ENDIF ()
 
-### Configuration
+# # # Configuration
 
 CONFIGURE_FILE (
-    "${CMAKE_MODULE_PATH}/${PROJECT_NAME}Config.cmake.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/${PROJECT_NAME}Config.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     @ONLY)
 
 CONFIGURE_FILE (
-    "${CMAKE_MODULE_PATH}/${PROJECT_NAME}ConfigVersion.cmake.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/${PROJECT_NAME}ConfigVersion.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
     @ONLY)
 
-INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" DESTINATION "${INSTALL_LIB}/${PROJECT_NAME}" COMPONENT "libraries")
-INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" DESTINATION "${INSTALL_LIB}/${PROJECT_NAME}" COMPONENT "libraries")
+INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" DESTINATION "${INSTALL_LIB}/cmake/${PROJECT_NAME}" COMPONENT "libraries")
+INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" DESTINATION "${INSTALL_LIB}/cmake/${PROJECT_NAME}" COMPONENT "libraries")
 
-### Uninstall
+# # # Uninstall
 
 CONFIGURE_FILE (
-    "${CMAKE_MODULE_PATH}/UninstallTarget.cmake.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/UninstallTarget.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/UninstallTarget.cmake"
     IMMEDIATE @ONLY)
 
 ADD_CUSTOM_TARGET ("uninstall" COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/UninstallTarget.cmake")
 
-### Misc
+# # # Misc
 
 INSTALL (FILES "LICENSE" DESTINATION ${INSTALL_ROOT} COMPONENT "documentation")
 
@@ -484,7 +494,7 @@ IF (EXISTS "${PROJECT_SOURCE_DIR}/share")
 
 ENDIF ()
 
-## Packaging
+# # Packaging
 
 SET (CPACK_PACKAGE_NAME ${PROJECT_PACKAGE_NAME})
 SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY ${PROJECT_DESCRIPTION})


### PR DESCRIPTION
This MR enable OSTk build without using Boost Stacktrace (compatibility issue with some targets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced options for building with Boost's stacktrace and static libraries.
	- Updated C++ standard from C++17 to C++20.
- **Improvements**
	- Enhanced organization of installation paths for configuration files.
	- Improved readability and clarity in build configuration structure.
- **Bug Fixes**
	- Adjusted error handling and messaging related to Boost library checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->