### PR TITLE
chore: package stubs in whl

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -146,11 +146,9 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/requirements.txt"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
-                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m build --no-isolation -w
+                            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/py.typed" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/py.typed"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m pip install .
-                            COMMAND python${PYTHON_VERSION} -c 'import sys\;from pybind11_stubgen.__init__ import main\;sys.exit(main())' "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" --ignore-invalid-expressions=".*regex.*|.*ConstIterator.*"  -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/stubs"
-                            COMMAND mv "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/stubs/${PROJECT_GROUP}/${PROJECT_SUBGROUP}/*.pyi" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}"
-                            COMMAND rm -r "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/stubs"
+                            COMMAND python${PYTHON_VERSION} -m "pybind11_stubgen" -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m build --no-isolation -w
                             COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/dist"
                             COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/dist/*" "${CMAKE_CURRENT_BINARY_DIR}/dist"


### PR DESCRIPTION
Simplifies stubgen to generate stubs and bundle them in the wheels. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Streamlined Python package directory generation process
	- Enhanced type hinting support for Python bindings
	- Simplified stub generation mechanism for the Open Space Toolkit Python package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->