### PR TITLE
build: prepare for test matrix

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
       - prepare-environment
       - build-development-image
       - test
-    uses: open-space-collective/open-space-toolkit/.github/workflows/build-packages.yml@fix/artifact-names
+    uses: open-space-collective/open-space-toolkit/.github/workflows/build-packages.yml@main
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,7 +67,7 @@ jobs:
       - prepare-environment
       - build-development-image
       - test
-    uses: open-space-collective/open-space-toolkit/.github/workflows/build-packages.yml@main
+    uses: open-space-collective/open-space-toolkit/.github/workflows/build-packages.yml@fix/artifact-names
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}

--- a/Makefile
+++ b/Makefile
@@ -522,6 +522,23 @@ test-unit-python-standalone: ## Run Python unit tests (standalone)
 
 .PHONY: test-unit-python-standalone
 
+ci-test-python: ## Run Python unit tests. Assumes the dev image has already been built, AND that bindings have been built and are available at `packages/python`
+
+	@ echo "Running Python unit tests..."
+
+	docker run \
+	--rm \
+	--volume="$(CURDIR):/app:delegated" \
+	--volume="/app/build" \
+	--workdir=/app/build \
+	$(docker_development_image_repository):$(docker_image_version) \
+	/bin/bash -c "python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} --find-links packages/python open_space_toolkit_${project_name} \
+	&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} plotly pandas \
+	&& cd ${test_python_directory}/ostk/$(project_name)/ \
+	&& python${test_python_version} -m pytest -sv ."
+
+.PHONY: ci-test-python
+
 test-coverage: ## Run test coverage cpp
 
 	@ echo "Running coverage tests..."


### PR DESCRIPTION
Adds a new Makefile directive to be used in CI to facilitate unit testing multiple Python versions. This should be merged BEFORE https://github.com/open-space-collective/open-space-toolkit/pull/144, and will only kick in after the latter is merged. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new Makefile target for running Python unit tests in continuous integration (CI) environments.
	- Provides a streamlined method for executing tests within a controlled Docker environment.
- **Changes**
	- Updated the GitHub Actions workflow to reference a new version for the packaging step, improving artifact naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->