### PR TITLE
build!: bump boost to 1.87

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ ENDFOREACH ()
 
 ## Dependencies
 
-### Boost [1.82.0]
+### Boost [1.87.0]
 IF (BUILD_WITH_BOOST_STATIC)
     SET (Boost_USE_STATIC_LIBS ON)
 ELSE ()
@@ -247,7 +247,7 @@ SET (Boost_USE_MULTITHREADED ON)
 
 IF (BUILD_WITH_BOOST_STACKTRACE)
 
-    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_backtrace")
+    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_backtrace")
 
     # Stacktrace definitions
 
@@ -272,7 +272,7 @@ IF (BUILD_WITH_BOOST_STACKTRACE)
     ADD_DEFINITIONS (-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
 
 ELSE ()
-    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_basic")
+    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_basic")
 ENDIF()
 
 

--- a/test/OpenSpaceToolkit/Core/FileSystem/Path.test.cpp
+++ b/test/OpenSpaceToolkit/Core/FileSystem/Path.test.cpp
@@ -323,7 +323,7 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetNormalizedPath)
         EXPECT_EQ(Path::Parse("/"), Path::Parse("/").getNormalizedPath());
         EXPECT_EQ(Path::Parse("/abc"), Path::Parse("/abc").getNormalizedPath());
         EXPECT_EQ(Path::Parse("/app"), Path::Parse("/app").getNormalizedPath());
-        EXPECT_EQ(Path::Parse("/app/"), Path::Parse("/app/").getNormalizedPath());
+        EXPECT_EQ(Path::Parse("/app"), Path::Parse("/app/").getNormalizedPath());
         EXPECT_EQ(Path::Parse("/app/build"), Path::Parse("/app/build").getNormalizedPath());
         EXPECT_EQ(Path::Parse("/app/build/Makefile"), Path::Parse("/app/build/Makefile").getNormalizedPath());
 


### PR DESCRIPTION
Bumps Boost dependency to 1.87, following the [bump in the base image](https://github.com/open-space-collective/open-space-toolkit/releases/tag/0.8.4). 

This introduces a potentially-breaking change, where `Path::getNormalizedPath()` will now trim trailing separators; this doesn't appear to impact downstream OSTk libraries. The cause seems to be a regression introduced in the [1.87 version of Boost-Filesystem](https://www.boost.org/doc/libs/1_87_0/libs/filesystem/doc/release_history.html) (potentially associated with the change [here](https://github.com/boostorg/filesystem/compare/boost-1.86.0...boost-1.87.0#diff-ef3cb21bb79a3b4f51c5ee8e8a28ee106a1c6ef1d441866d2d4c27adce982eaf)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
  - Upgraded Boost library from version 1.82.0 to 1.87.0

- **Bug Fixes**
  - Updated path normalization to remove trailing slashes consistently

<!-- end of auto-generated comment: release notes by coderabbit.ai -->