### PR TITLE
fix: remove py.typed file

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -146,7 +146,6 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/requirements.txt"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
-                            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/py.typed" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/py.typed"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m pip install .
                             COMMAND python${PYTHON_VERSION} -m "pybind11_stubgen" -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
                             COMMAND find "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_GROUP}" -type f -name "*.pyi" -exec sed -i "s/: \\\\.\\\\.\\\\./: typing.Any/g" {} + # crudely fix stubs with invalid syntax


### PR DESCRIPTION
The auto-generated stubs introduced in https://github.com/open-space-collective/open-space-toolkit-core/pull/175 appear too strict for mypy, leading to a lot of noise when running mypy through files using OSTk bindings.  

For example, mypy throws an error on [this line](https://github.com/open-space-collective/open-space-toolkit-core/blob/b9f5635ff62ca2b2ecad0da9307a441ebbef3d6c/bindings/python/test/containers/test_dictionary.py#L74) because the `Dictionary` class expects an `ostk.core.type.String` rather than a native Python string, even though it's perfectly valid in runtime. 

Until these stubs can be modified to be more accurate, we're opting to remove the `py.typed` file from the Python package, effectively "unmarking" OSTk as [PEP 561](https://peps.python.org/pep-0561/)-compliant which means mypy will skip analysing this package. The stubs are left in because they can still be used by LSPs to facilitate code completion.

For users wishing to type-check OSTk regardless, they may do so by adding [`follow_untyped_imports`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-follow_untyped_imports) for `ostk.*` to their mypy config. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Python package build configuration to remove `py.typed` file copying during wheel build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->