### PR TITLE
build: loosen boost version requirement to 1.82

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ ENDFOREACH ()
 
 ## Dependencies
 
-### Boost [1.87.0]
+### Boost [1.82.0]
 IF (BUILD_WITH_BOOST_STATIC)
     SET (Boost_USE_STATIC_LIBS ON)
 ELSE ()
@@ -247,7 +247,7 @@ SET (Boost_USE_MULTITHREADED ON)
 
 IF (BUILD_WITH_BOOST_STACKTRACE)
 
-    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_backtrace")
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_backtrace")
 
     # Stacktrace definitions
 
@@ -272,7 +272,7 @@ IF (BUILD_WITH_BOOST_STACKTRACE)
     ADD_DEFINITIONS (-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
 
 ELSE ()
-    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_basic")
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "system" "filesystem" "regex" "log" "stacktrace_basic")
 ENDIF()
 
 

--- a/test/OpenSpaceToolkit/Core/FileSystem/Path.test.cpp
+++ b/test/OpenSpaceToolkit/Core/FileSystem/Path.test.cpp
@@ -1,5 +1,7 @@
 /// Apache License 2.0
 
+#include <boost/version.hpp>
+
 #include <OpenSpaceToolkit/Core/FileSystem/Path.hpp>
 
 #include <Global.test.hpp>
@@ -323,7 +325,18 @@ TEST(OpenSpaceToolkit_Core_FileSystem_Path, GetNormalizedPath)
         EXPECT_EQ(Path::Parse("/"), Path::Parse("/").getNormalizedPath());
         EXPECT_EQ(Path::Parse("/abc"), Path::Parse("/abc").getNormalizedPath());
         EXPECT_EQ(Path::Parse("/app"), Path::Parse("/app").getNormalizedPath());
-        EXPECT_EQ(Path::Parse("/app"), Path::Parse("/app/").getNormalizedPath());
+
+        // Changed behaviour when using Boost >=1.87
+        // see https://github.com/open-space-collective/open-space-toolkit-core/pull/177
+        if ((BOOST_VERSION / 100) % 1000 >= 87)
+        {
+            EXPECT_EQ(Path::Parse("/app"), Path::Parse("/app/").getNormalizedPath());
+        }
+        else
+        {
+            EXPECT_EQ(Path::Parse("/app/"), Path::Parse("/app/").getNormalizedPath());
+        }
+
         EXPECT_EQ(Path::Parse("/app/build"), Path::Parse("/app/build").getNormalizedPath());
         EXPECT_EQ(Path::Parse("/app/build/Makefile"), Path::Parse("/app/build/Makefile").getNormalizedPath());
 


### PR DESCRIPTION
Loosen the requirements on Boost versions to allow older versions that what's in the [root repository](https://github.com/open-space-collective/open-space-toolkit/blob/main/docker/development/Dockerfile#L156). Although the binaries released here will still ship with a statically-compiled Boost lib matching that of the root repo's, those who build OSTk from source may now use a wider range of versions. The unit tests should pass regardless of which supported Boost version is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated Boost library version requirement from 1.87.0 to 1.82.0 in project configuration

- **Testing**
	- Modified test case for path normalization to handle different Boost library version behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->