### PR TITLE
build: use underscore in setup.cfg

### DIFF
--- a/bindings/python/tools/python/setup.cfg.in
+++ b/bindings/python/tools/python/setup.cfg.in
@@ -1,7 +1,7 @@
 # Apache License 2.0
 
 [bdist_wheel]
-python-tag=py${EXTENSION}
+python_tag=py${EXTENSION}
 bdist_dir=./dist${EXTENSION}
 plat_name=${PLATFORM}
 


### PR DESCRIPTION
I somehow missed the actual example warning itself when applying the fixes in [this PR](https://github.com/open-space-collective/open-space-toolkit-core/pull/181) 🤦 

Other OSTk repos were already fixed in their original PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Python package configuration to use the correct configuration key for wheel distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->