### PR TITLE
style: re-run format with clang 18

### DIFF
--- a/src/OpenSpaceToolkit/Core/Container/Object.cpp
+++ b/src/OpenSpaceToolkit/Core/Container/Object.cpp
@@ -871,8 +871,8 @@ Object Object::ParseJson(const type::String& aString)
         return Object::Undefined();
     }
 
-    std::function<Object(const rapidjson::Value&)> parseJson =
-        [&parseJson](const rapidjson::Value& aJsonValue) -> Object
+    std::function<Object(const rapidjson::Value&)> parseJson = [&parseJson](const rapidjson::Value& aJsonValue
+                                                               ) -> Object
     {
         if (aJsonValue.IsNull())  // Value is Null
         {
@@ -942,8 +942,8 @@ Object Object::ParseJson(const type::String& aString)
 
     rapidjson::Document jsonDocument;
 
-    if (jsonDocument.ParseStream < rapidjson::kParseNanAndInfFlag |
-        rapidjson::kParseCommentsFlag > (jsonStream).HasParseError())
+    if (jsonDocument.ParseStream<rapidjson::kParseNanAndInfFlag | rapidjson::kParseCommentsFlag>(jsonStream)
+            .HasParseError())
     {
         throw ostk::core::error::RuntimeError("Cannot parse JSON string [" + aString + "].");
     }

--- a/test/OpenSpaceToolkit/Core/Container/Array.test.cpp
+++ b/test/OpenSpaceToolkit/Core/Container/Array.test.cpp
@@ -491,16 +491,14 @@ TEST(OpenSpaceToolkit_Core_Container_Array, Map)
     }
 
     {
-        EXPECT_TRUE(
-            Array<String>::Empty()
-                .map<String>(
-                    [](const String& aString) -> String
-                    {
-                        return aString;
-                    }
-                )
-                .isEmpty()
-        );
+        EXPECT_TRUE(Array<String>::Empty()
+                        .map<String>(
+                            [](const String& aString) -> String
+                            {
+                                return aString;
+                            }
+                        )
+                        .isEmpty());
     }
 }
 

--- a/test/OpenSpaceToolkit/Core/Container/Dictionary.test.cpp
+++ b/test/OpenSpaceToolkit/Core/Container/Dictionary.test.cpp
@@ -277,9 +277,8 @@ TEST(OpenSpaceToolkit_Core_Container_Dictionary, KeySubscriptOperator)
               {"Integer", Object::Integer(456)},
               {"Real", Object::Real(456.789)},
               {"Dictionary",
-               {{"Boolean", Object::Boolean(true)},
-                {"Integer", Object::Integer(789)},
-                {"Real", Object::Real(789.123)}}}}}
+               {{"Boolean", Object::Boolean(true)}, {"Integer", Object::Integer(789)}, {"Real", Object::Real(789.123)}}}
+             }}
         };
 
         EXPECT_EQ(true, dictionary["Boolean"].getBoolean());

--- a/test/OpenSpaceToolkit/Core/Type/Integer.test.cpp
+++ b/test/OpenSpaceToolkit/Core/Type/Integer.test.cpp
@@ -2851,11 +2851,9 @@ TEST(OpenSpaceToolkit_Core_Type_Integer, Uint16)
         EXPECT_NO_THROW(Integer::Uint16(ostk::core::type::Uint16(std::numeric_limits<ostk::core::type::Uint8>::min())));
         EXPECT_NO_THROW(Integer::Uint16(ostk::core::type::Uint16(std::numeric_limits<ostk::core::type::Uint8>::max())));
 
-        EXPECT_NO_THROW(
-            Integer::Uint16(ostk::core::type::Uint16(std::numeric_limits<ostk::core::type::Uint16>::min()))
+        EXPECT_NO_THROW(Integer::Uint16(ostk::core::type::Uint16(std::numeric_limits<ostk::core::type::Uint16>::min()))
         );
-        EXPECT_NO_THROW(
-            Integer::Uint16(ostk::core::type::Uint16(std::numeric_limits<ostk::core::type::Uint16>::max()))
+        EXPECT_NO_THROW(Integer::Uint16(ostk::core::type::Uint16(std::numeric_limits<ostk::core::type::Uint16>::max()))
         );
     }
 
@@ -2896,19 +2894,15 @@ TEST(OpenSpaceToolkit_Core_Type_Integer, Uint32)
         EXPECT_NO_THROW(Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint8>::min())));
         EXPECT_NO_THROW(Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint8>::min())));
 
-        EXPECT_NO_THROW(
-            Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint16>::min()))
+        EXPECT_NO_THROW(Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint16>::min()))
         );
-        EXPECT_NO_THROW(
-            Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint16>::min()))
+        EXPECT_NO_THROW(Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint16>::min()))
         );
 
-        EXPECT_NO_THROW(
-            Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint32>::min()))
+        EXPECT_NO_THROW(Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint32>::min()))
         );
 
-        EXPECT_ANY_THROW(
-            Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint32>::max()))
+        EXPECT_ANY_THROW(Integer::Uint32(ostk::core::type::Uint32(std::numeric_limits<ostk::core::type::Uint32>::max()))
         );
     }
 
@@ -2954,26 +2948,20 @@ TEST(OpenSpaceToolkit_Core_Type_Integer, Uint64)
         EXPECT_NO_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint8>::min())));
         EXPECT_NO_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint8>::max())));
 
-        EXPECT_NO_THROW(
-            Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint16>::min()))
+        EXPECT_NO_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint16>::min()))
         );
-        EXPECT_NO_THROW(
-            Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint16>::max()))
+        EXPECT_NO_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint16>::max()))
         );
 
-        EXPECT_NO_THROW(
-            Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint32>::min()))
+        EXPECT_NO_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint32>::min()))
         );
 
-        EXPECT_NO_THROW(
-            Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint64>::min()))
+        EXPECT_NO_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint64>::min()))
         );
 
-        EXPECT_ANY_THROW(
-            Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint32>::max()))
+        EXPECT_ANY_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint32>::max()))
         );
-        EXPECT_ANY_THROW(
-            Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint64>::max()))
+        EXPECT_ANY_THROW(Integer::Uint64(ostk::core::type::Uint64(std::numeric_limits<ostk::core::type::Uint64>::max()))
         );
     }
 


### PR DESCRIPTION
[This PR](https://github.com/open-space-collective/open-space-toolkit/pull/169) freezes the `clang` version to 18, which is the latest stable version. This repo had been previously formatted with v20, so I'm re-running `ostk-format-cpp` with v18. 

Contains no changes to business logic. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code formatting to enhance readability and maintain internal consistency.
- **Tests**
  - Streamlined test assertions and data setups for a more concise, clear testing suite while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->