### PR TITLE
ci: use correct target when building release image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}
+      target: ci-base
     secrets: inherit
 
   test:


### PR DESCRIPTION
To fix https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/29265998746/job/86871245101

Had to specify the build target in the release workflow too