### PR TITLE
build: fix packaging

### DIFF
--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -41,7 +41,7 @@ ext-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["ostk.core"]
+include = ["ostk.core", "ostk.core.*"]
 
 [tool.setuptools.package-data]
 "ostk.core" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so"]


### PR DESCRIPTION
"submodules" weren't packaged. In this case, I don't think anything was missing because ostk-core doesn't contain any "submodules", but this is kept in symmetry with other OSTk repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Python package distribution so all `ostk.core` subpackages are included when installing the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->