### PR TITLE
build: fix requires-python to permit >=3.9

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -152,7 +152,7 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${SHARED_LIBRARY_TARGET}" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}"
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
-                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv sync --all-extras
+                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv sync --python ${PYTHON_VERSION} --all-extras
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv run pybind11-stubgen -o . "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
                             COMMAND find "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_GROUP}" -type f -name "*.pyi" -exec sed -i "s/: \\\\.\\\\.\\\\./: typing.Any/g" {} + # crudely fix broken stubs; need to escape \\
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && env _PYTHON_HOST_PLATFORM="${PLATFORM}" uv build

--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: POSIX :: Linux",
 ]
-requires-python = "~=${PYTHON_VERSION}.0"
+requires-python = ">=3.9"
 
 dependencies = [] # no runtime dependencies for ostk-core, but kept for symmetry with higher-level OSTk packages
 


### PR DESCRIPTION
- We build a Python package per-Python-version, and also per-architecture, due to requiring specific CPythons for each
- Each package has their own "rendered" version of the `pyproject.toml.in`, which now includes a specific `requires-python` key.
- However, when we upload these packages to PyPI (of the same release version), the _first_ file's `requires-python` is used as the project-wide metadata for that version.
- Alphabetically, the `3.10` package gets uploaded first, so the entire project was restricted to _only_ 3.10 despite uploading whls for the other versions.
<img width="297" height="224" alt="image" src="https://github.com/user-attachments/assets/36da65a2-5f96-465c-8a24-d869481c111f" />

- For `pip`, this meant that newer OSTks were _only_ available for 3.10
- For `uv`, _only_ 3.9 was impacted because `uv` [only respects the lower bound](https://docs.astral.sh/uv/concepts/resolution/#universal-resolution) of `requires-python`
<img width="884" height="118" alt="image" src="https://github.com/user-attachments/assets/c3c215ef-cb6a-4218-889c-2fc025849ccc" />

- The original reason for the stricter version pin was to [indicate to uv](https://github.com/open-space-collective/open-space-toolkit/pull/181) which python version to use when setting up the build environment, but we can just directly supply this in the `uv sync` command instead. 
- Actual python version resolution still happens based on the whl filenames, as they always have