### PR TITLE
build: add python3.14

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -195,7 +195,7 @@ FOREACH (PYTHON_VERSION ${PYTHON_SEARCH_VERSIONS})
         MESSAGE (STATUS "Python ${PYTHON_VERSION} found.")
         LIST (APPEND PYTHON_VERSIONS ${PYTHON_VERSION})
     ELSE ()
-        MESSAGE (STATUS "Python ${PYTHON_VERSION} not found.")
+        MESSAGE (FATAL_ERROR "Python ${PYTHON_VERSION} was requested but not found.")
     ENDIF ()
 ENDFOREACH ()
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -186,7 +186,7 @@ FIND_PACKAGE (pybind11 2.12.0 REQUIRED)
 ### Python
 
 # Python versions to build for and support
-SET (PYTHON_SEARCH_VERSIONS 3.9 3.10 3.11 3.12 3.13 CACHE STRING "Versions of Python bindings to build.")
+SET (PYTHON_SEARCH_VERSIONS 3.9 3.10 3.11 3.12 3.13 3.14 CACHE STRING "Versions of Python bindings to build.")
 
 MESSAGE (STATUS "Looking for available python versions...")
 FOREACH (PYTHON_VERSION ${PYTHON_SEARCH_VERSIONS})

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,6 +1,6 @@
 # Apache License 2.0
 
-ARG BASE_IMAGE_VERSION="0.11.0-7-ge13e0f7"
+ARG BASE_IMAGE_VERSION="latest"
 
 # General purpose development image (root user)
 FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} AS root-user

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,6 +1,6 @@
 # Apache License 2.0
 
-ARG BASE_IMAGE_VERSION="latest"
+ARG BASE_IMAGE_VERSION="0.11.0-7-ge13e0f7"
 
 # General purpose development image (root user)
 FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} AS root-user


### PR DESCRIPTION
Needs https://github.com/open-space-collective/open-space-toolkit/pull/187

Also throws a fatal error if a requested Python version is NOT found, rather than just not building it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Python builds now stop with a clear configuration error when a specifically requested Python version or its headers cannot be found.
  - Prevents builds from continuing with an unavailable Python development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->