### PR TITLE
chore: don't overwrite devcontainer venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,7 @@ start-development dev: build-development-image-non-root ## Start development env
 		-it \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
+		--volume="/app/bindings/python/.venv" \
 		--volume="$(HOME)/.ssh:/home/$(dev_username)/.ssh:ro" \
 		--volume="$(HOME)/.gitconfig:/home/$(dev_username)/.gitconfig:ro" \
 		--workdir=/app/build \


### PR DESCRIPTION
see https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the development environment by preserving the Python virtual environment when running the application in Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->